### PR TITLE
Remove unnecessary options to get conventions unified

### DIFF
--- a/PinnacleCodingConvention/Commands/CleanUpCommandHandler.cs
+++ b/PinnacleCodingConvention/Commands/CleanUpCommandHandler.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using PinnacleCodingConvention.Services;
-using System;
 using System.ComponentModel.Composition;
 
 namespace PinnacleCodingConvention.Commands
@@ -15,7 +14,7 @@ namespace PinnacleCodingConvention.Commands
     [Name(nameof(CleanUpCommandHandler))]
     [ContentType("code")]
     [TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
-    [Order(Before = "CodeCleanUpProfileCommandHandler")]
+    [Order(After = "CodeCleanUpProfileCommandHandler")]
     internal class CleanUpCommandHandler : ICommandHandler<CleanUpCommandArgs>
     {
         public string DisplayName => nameof(CleanUpCommandHandler);
@@ -34,7 +33,7 @@ namespace PinnacleCodingConvention.Commands
             var commandManager = CleanUpManager.GetInstance(ide);
             commandManager.Execute(ide.ActiveDocument);
 
-            return false;
+            return true;
         }
 
         public CommandState GetCommandState(CleanUpCommandArgs args) => CommandState.Available;

--- a/PinnacleCodingConvention/Commands/CodeCleanUpProfileCommandHandler.cs
+++ b/PinnacleCodingConvention/Commands/CodeCleanUpProfileCommandHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.Commanding;
-using Microsoft.VisualStudio.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.Commanding;
 using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
@@ -46,7 +45,7 @@ namespace PinnacleCodingConvention.Commands
                 OutputWindowHelper.WriteError(ex.Message);
             }
 
-            return true;
+            return false;
         }
 
         public CommandState GetCommandState(CleanUpCommandArgs args) => CommandState.Available;

--- a/PinnacleCodingConvention/Helpers/CodeItemTypeComparer.cs
+++ b/PinnacleCodingConvention/Helpers/CodeItemTypeComparer.cs
@@ -92,11 +92,7 @@ namespace PinnacleCodingConvention.Helpers
 
         private static int CalculateReadOnlyOffset(BaseCodeItem codeItem)
         {
-            var codeItemField = codeItem as CodeItemField;
-            if (codeItemField == null || !GeneralOptions.Instance.OrderByAccessLevelFirst)
-                return 0;
-
-            return codeItemField.IsReadOnly ? 0 : 1;
+            return codeItem is CodeItemField codeItemField && codeItemField.IsReadOnly ? 0 : 1;
         }
 
         private static string NormalizeName(BaseCodeItem codeItem)
@@ -112,9 +108,6 @@ namespace PinnacleCodingConvention.Helpers
                 if (0 < dotPosition && dotPosition < name.Length)
                     return name.Substring(dotPosition);
             }
-
-            if (GeneralOptions.Instance.PageLoadFirst && name.EndsWith("Page_Load"))
-                return $"__{name}";
 
             return name;
         }

--- a/PinnacleCodingConvention/Models/CodeItems/CodeItemField.cs
+++ b/PinnacleCodingConvention/Models/CodeItems/CodeItemField.cs
@@ -39,7 +39,7 @@ namespace PinnacleCodingConvention.Models.CodeItems
         /// <summary>
         /// Gets the kind.
         /// </summary>
-        public override KindCodeItem Kind => GeneralOptions.Instance.IsSeparateConstAndVar && IsConstant ? KindCodeItem.Constants : KindCodeItem.Field;
+        public override KindCodeItem Kind => IsConstant ? KindCodeItem.Constants : KindCodeItem.Field;
 
         /// <summary>
         /// Loads all lazy initialized values immediately.

--- a/PinnacleCodingConvention/Options/GeneralOptions.cs
+++ b/PinnacleCodingConvention/Options/GeneralOptions.cs
@@ -4,24 +4,8 @@ namespace PinnacleCodingConvention.Options
 {
     internal class GeneralOptions : BaseOptionModel<GeneralOptions>
     {
-        [DisplayName("Separate Constants and Variables")]
-        [Description("Separate class constants and class variables into different regions")]
-        [DefaultValue(false)]
-        public bool IsSeparateConstAndVar { get; set; }
-
-
-        [DisplayName("Order By Access Level first")]
-        [Description("Order the class variables by Access Level then Name")]
-        [DefaultValue(true)]
-        public bool OrderByAccessLevelFirst { get; set; }
-
-        [DisplayName("Keep Page_Load on top")]
-        [Description("Always keep Page_Load and Pinnacle_Page_Load on top of Methods region")]
-        [DefaultValue(false)]
-        public bool PageLoadFirst { get; set; }
-
-        [DisplayName("Profile")]
-        [Description("Specifies whether to run Code Clean up automatically on save or not.")]
+        [DisplayName("Code Cleanup Profile")]
+        [Description("Specify Code Cleanup Profile to be run automatically.")]
         [DefaultValue(CodeCleanupProfile.Profile1)]
         [TypeConverter(typeof(EnumConverter))]
         public CodeCleanupProfile Profile { get; set; } = CodeCleanupProfile.Profile1;

--- a/PinnacleCodingConvention/Services/BlankLineInsertService.cs
+++ b/PinnacleCodingConvention/Services/BlankLineInsertService.cs
@@ -38,6 +38,7 @@ namespace PinnacleCodingConvention.Services
         /// <param name="codeItems"></param>
         internal void InsertPaddings(IEnumerable<BaseCodeItem> codeItems)
         {
+            var itemsToAddPaddings = new List<BaseCodeItem>();
             foreach (var codeItem in codeItems)
             {
                 if (codeItem is ICodeItemParent itemAsParent)
@@ -54,8 +55,10 @@ namespace PinnacleCodingConvention.Services
                     {
                         InsertPaddings(itemAsParent.Children);
                     }
+                    itemsToAddPaddings.Add(codeItem);
                 }
             }
+            InsertPaddingBeforeAndAfter(itemsToAddPaddings);
         }
 
         private void InsertPaddingsToItemsInClass(IEnumerable<BaseCodeItem> codeItems)
@@ -67,7 +70,7 @@ namespace PinnacleCodingConvention.Services
                 InsertPaddingAfterCodeElements(new[] { lastConstantItem });
             }
 
-            var itemsToAddPaddings = codeItems.Where(item => item is CodeItemMethod || (item is CodeItemProperty && item.StartLine != item.EndLine));
+            var itemsToAddPaddings = codeItems.Where(item => item is CodeItemMethod || (item is CodeItemProperty && item.IsMultiLine));
             InsertPaddingBeforeAndAfter(itemsToAddPaddings);
         }
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ It helps developers to avoid some tedious NW in code review, e.g. A-Z order, mis
 
 ## Release 
 
+### 1.1.9
+- Remove unnecessary options to get conventions unified:
+    - Do not treat "Page_Load" as a special one (always sort by alphabetical order)
+    - Do separate class consts and others
+    - Do put "readonly" fields before others
+
 ### 1.1.8
 - Do not add regions, and remove existing regions.
 - Group by sections:


### PR DESCRIPTION
- Remove unnecessary options to get conventions unified:
    - Do not treat "Page_Load" as a special one (always sort by alphabetical order)
    - Do separate class consts and others
    - Do put "readonly" fields before other